### PR TITLE
2.2.0

### DIFF
--- a/src/SoCreate.Extensions.Caching.ServiceFabric/SoCreate.Extensions.Caching.ServiceFabric.csproj
+++ b/src/SoCreate.Extensions.Caching.ServiceFabric/SoCreate.Extensions.Caching.ServiceFabric.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>http://service-fabric-distributed-cache.socreate.it/</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <Copyright>© SoCreate. All rights reserved.</Copyright>
-    <Version>2.1.3</Version>
+    <Version>2.2.0</Version>
     <PackageIconUrl>https://raw.githubusercontent.com/SoCreate/service-fabric-distributed-cache/master/assets/icon-64x64.png</PackageIconUrl>
   </PropertyGroup>
 


### PR DESCRIPTION
Incrementing minor version because the [previous PR](https://github.com/SoCreate/service-fabric-distributed-cache/pull/22) upgraded dependencies that also went up minor versions.