### PR TITLE
Support for custom serialization providers

### DIFF
--- a/src/SoCreate.Extensions.Caching.ServiceFabric/ServiceFabricCacheOptions.cs
+++ b/src/SoCreate.Extensions.Caching.ServiceFabric/ServiceFabricCacheOptions.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.Extensions.Options;
+using Microsoft.ServiceFabric.Services.Remoting.V2;
 using System;
 
 namespace SoCreate.Extensions.Caching.ServiceFabric
@@ -11,5 +12,6 @@ namespace SoCreate.Extensions.Caching.ServiceFabric
         public string CacheStoreEndpointName { get; set; }
         public Guid CacheStoreId { get; set; }
         public TimeSpan? RetryTimeout { get; set; }
+        public IServiceRemotingMessageSerializationProvider SerializationProvider { get; set; }
     }
 }

--- a/src/SoCreate.Extensions.Caching.ServiceFabric/SoCreate.Extensions.Caching.ServiceFabric.csproj
+++ b/src/SoCreate.Extensions.Caching.ServiceFabric/SoCreate.Extensions.Caching.ServiceFabric.csproj
@@ -13,7 +13,7 @@
     <PackageProjectUrl>http://service-fabric-distributed-cache.socreate.it/</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
     <Copyright>© SoCreate. All rights reserved.</Copyright>
-    <Version>3.0.0</Version>
+    <Version>3.1.0</Version>
     <PackageIconUrl>https://raw.githubusercontent.com/SoCreate/service-fabric-distributed-cache/master/assets/icon-64x64.png</PackageIconUrl>
   </PropertyGroup>
 

--- a/tests/SoCreate.Extensions.Caching.Tests/SoCreate.Extensions.Caching.Tests.csproj
+++ b/tests/SoCreate.Extensions.Caching.Tests/SoCreate.Extensions.Caching.Tests.csproj
@@ -12,9 +12,10 @@
     <PackageReference Include="AutoFixture.Xunit2" Version="4.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
     <PackageReference Include="Microsoft.ServiceFabric" Version="9.0.*" />
-    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="6.0.1017" />
+    <PackageReference Include="Microsoft.ServiceFabric.Actors" Version="6.0.1121" />
+    <PackageReference Include="Microsoft.ServiceFabric.Services.Remoting" Version="6.0.1121" />
     <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="ServiceFabric.Mocks" Version="6.0.*" />
+    <PackageReference Include="ServiceFabric.Mocks" Version="6.1.4" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This change adds support for using custom serialization providers in the communication between ServiceFabric services. I've tested this change using [Microsoft's sample JSON SerializationProvider](https://github.com/suchiagicha/Samples/blob/a2f2a6a545b98cdf7415fca209f7e2f858a452e9/ActorCustomSerializer/Actor1.Interfaces/JsonSerializationProvider.cs), but any provider should be able to be passed in when the service is created at startup. Identical custom serializers will need to be passed into both the client facing service and the internal service. 

For example, when using the JSON Serializer in ClientApp and DistributedCacheStore, we'd do the following to register the SerializationProvider:

#### ClientApp/Startup.cs
```c#
services.Configure<ServiceFabricCacheOptions>(o => {
    o.RetryTimeout = TimeSpan.FromSeconds(5);
    o.SerializationProvider = new ServiceRemotingJsonSerializationProvider();
  });
```

#### DistributedCacheStore/DistributedCacheStore.cs
```c#
public DistributedCacheStore(StatefulServiceContext context)
   : base(context, (message) => ServiceEventSource.Current.ServiceMessage(context, message), serializationProvider: new ServiceRemotingJsonSerializationProvider())
 { }
```
 